### PR TITLE
🐛 Update hr tag replacement in Steam parser

### DIFF
--- a/src/plugins/patches/platforms/steam.rs
+++ b/src/plugins/patches/platforms/steam.rs
@@ -83,7 +83,7 @@ impl Steam {
             .replace("[/h2]", "\n")
             .replace("[h3]", "")
             .replace("[/h3]", "\n")
-            .replace("[hr]", "---\n")
+            .replace("[hr]", "——————\n")
             .replace("[/hr]", "")
             .replace("\\[", "[");
         let re = Regex::new(r"\[img](.*?)\[/img]").unwrap();
@@ -96,7 +96,8 @@ impl Steam {
             images.push(path.replace("{STEAM_CLAN_IMAGE}", STEAM_CLAN_IMAGE));
         }
         let re3 = Regex::new(r"\[url=(.*?)](.*?)\[/url]").unwrap();
-        let re_youtube = Regex::new(r"\[previewyoutube=(.*?)]\[/previewyoutube]").unwrap();
+        let re_youtube =
+            Regex::new(r"\[previewyoutube=(.*?)]\[/previewyoutube]").unwrap();
         // Remove img tags from content
         let parsed_content_1 = re.replace_all(&content, "");
         let parsed_content_2 = re2.replace_all(&parsed_content_1, "");
@@ -115,10 +116,11 @@ impl Steam {
         if images.len() > 0 {
             image = &images[0];
         }
-        let truncated_content = match parsed_trimmed_content.char_indices().nth(400) {
-            None => parsed_trimmed_content,
-            Some((idx, _)) => &parsed_trimmed_content[..idx],
-        };
+        let truncated_content =
+            match parsed_trimmed_content.char_indices().nth(400) {
+                None => parsed_trimmed_content,
+                Some((idx, _)) => &parsed_trimmed_content[..idx],
+            };
 
         Some(SteamNews {
             title: patch_notes_title,


### PR DESCRIPTION
Changes dashes to em-dash in steam parser for the `[hr]` tag, as it looks slightly better in Discord.